### PR TITLE
ScrollingMap: Fixed data lifetime issue with scroll updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ Thumbs.db
 
 # Folder config file
 Desktop.ini
+
+rom.gen
+rom.map
+res.h
+src/*.swp

--- a/res.h
+++ b/res.h
@@ -1,4 +1,0 @@
-#ifndef _RES_AUTOGEN_H
-#define _RES_AUTOGEN_H
-extern const uint8_t res_res_txt[25];
-#endif  // _RES_AUTOGEN_H

--- a/src/ScrollingMap.h
+++ b/src/ScrollingMap.h
@@ -13,7 +13,6 @@
 
 void ScrollingMap_init();
 void ScrollingMap_update();
-void ScrollingMap_updateVDP();
 
 // TODO -- Set this equal to the maximum allowed map height (in tiles), divided by 2.
 // If ROW_OFFSET_COUNT == 128, the maximum map height is 256 tiles (2048 pixels).

--- a/src/main.c
+++ b/src/main.c
@@ -22,9 +22,6 @@ int main()
     {
         Joypad_update();
         ScrollingMap_update();
-
-        // Wait for VBlank
         megadrive_finish();
-        ScrollingMap_updateVDP();
     }
 }


### PR DESCRIPTION
* Added persistent data storage for scroll coordinates to ScrollingMap
* Scheduled DMA before megadrive_finish() to remove a frame of delay
* Added build artifacts to .gitignore
* Updated MDK